### PR TITLE
Agregada las distribuciones de los productos y generacion de ingresos

### DIFF
--- a/Logistica_dj/Logistica/Logistica/urls.py
+++ b/Logistica_dj/Logistica/Logistica/urls.py
@@ -17,7 +17,7 @@ from django.contrib import admin
 from django.urls import path
 from django.conf.urls import url
 from Movimientos.views import *
-from Stock.views import *
+#from Stock.views import *
 
 #, includes
 #path('admin/', include('material.admin.urls')),
@@ -25,7 +25,7 @@ from Stock.views import *
 urlpatterns = [
     path('', admin.site.urls),
     path('remito/<int:id_context>/', PDF.as_view(), name="REMITO"),
-    path('stock', Stock.as_view() ,name="Stock")
+    #path('stock', Stock.as_view() ,name="Stock")
 ]
 
 admin.site.site_header = 'Logística MTE - CTEP'

--- a/Logistica_dj/Logistica/Movimientos/admin.py
+++ b/Logistica_dj/Logistica/Movimientos/admin.py
@@ -1,12 +1,75 @@
 from django.contrib import admin
-from .models import EgresosPuntoDeRecepcion, IngresosAPuntosDeRecepcion, LineaDeEgr, LineaDeIng
+from django.shortcuts import redirect
+from django.urls import reverse
+
+from .models import EgresosPuntoDeRecepcion, IngresosAPuntosDeRecepcion, LineaDeEgr, LineaDeIng, Distribucion, \
+    DistribucionProducto, LineaDistribucionProducto
 from import_export import resources
 from import_export.admin import ImportExportModelAdmin
 from django.utils.safestring import mark_safe
 
 
-# Register your models here.
+# Acciones adicionales
+def make_egresos_de_ingresos(modeladmin, request, queryset):
+    for obj in queryset:
+        if obj.estado == 'Validado': # ver como preguntar en funcion de IngresoPR.ESTADOS
+            try:
+                distribucion = Distribucion.objects.get(ingreso=obj)
+            except Distribucion.DoesNotExist:
+                pass
+                return #aca deberia mandar un mensaje de que no hay distribuciones para ese ingreso y salir
 
+            distribuciones = DistribucionProducto.objects.filter(distribucion=distribucion)
+            egresos = []
+            for dist in distribuciones: # recorrro los productos de la distribucion
+                # recorro los pc y genero un egreso para cada uno
+                lineasDistribucionProducto = LineaDistribucionProducto.objects.filter(distribucion=dist)
+                for pcs in lineasDistribucionProducto:
+                    if pcs.pc not in [e.destino for e in egresos]: #si todavia no agregue el pc lo agrego
+                        egreso = EgresosPuntoDeRecepcion()
+                        egreso.destino = pcs.pc
+                        egreso.origen = obj.destino # ver esto
+                        egreso.save()
+                        egresos.append(egreso)
+
+            for egr in egresos: # recorro los egresos generados
+                for dist in distribuciones: # recorro los productos de la distribucion
+                    lineasDistribucionProducto = LineaDistribucionProducto.objects.filter(distribucion=dist)
+
+                    try:
+                        lineaIngreso = LineaDeIng.objects.get(movimiento=obj, producto=dist.producto)
+                        # traigo linea de ingreso de ese producto
+                        # mensaje de error hay dos productos iguales en distintas lineas en el ingreso puede
+                        # arreglarse sobrecargando el formset_save() de ingresos
+                        for pcs in lineasDistribucionProducto: # recorro los pcs de la distribucion actual
+                            if pcs.pc == egr.destino:
+                                lineaEgreso = LineaDeEgr()
+                                lineaEgreso.producto = dist.producto
+                                lineaEgreso.movimiento = egr
+                                lineaEgreso.cantidad = (pcs.porcentaje * lineaIngreso.cantidad) / 100
+                                if lineaIngreso.cantidad > 0:
+                                    lineaEgreso.save()
+                    except LineaDeIng.DoesNotExist or LineaDeIng.MultipleObjectsReturned:
+                        pass
+        else:
+            pass# aca deberia ir un mensaje de que se debe validar el ingreso para poder generar los egresos
+
+make_egresos_de_ingresos.short_description = 'Generar egresos asociados'
+
+
+def make_carga_productos_automatica(modeladmin, request, queryset):
+    for obj in queryset:
+        lineasIngreso = LineaDeIng.objects.filter(movimiento=obj.ingreso)
+        for linea in lineasIngreso:
+            nuevaLineaDistribucion = DistribucionProducto()
+            nuevaLineaDistribucion.producto = linea.producto
+            nuevaLineaDistribucion.distribucion = obj
+            nuevaLineaDistribucion.save()
+
+make_carga_productos_automatica.short_description = 'Cargar Productos desde ingreso asociado'
+
+
+# Register your models here.
 class MovimientosEgresosPRResource(resources.ModelResource):
     class Meta:
         model = EgresosPuntoDeRecepcion
@@ -46,6 +109,7 @@ class IngPRAdmin(ImportExportModelAdmin,admin.ModelAdmin):
     resource_class = MovimientosIngresosPRResource
     list_display = [id, 'fecha_y_hora_de_ingreso','origen', 'destino', 'estado']
     search_fields = [id, 'origen', 'destino', 'estado']
+    actions = [make_egresos_de_ingresos]
 
 
 class EgrPRAdmin(ImportExportModelAdmin, admin.ModelAdmin):
@@ -62,6 +126,96 @@ class EgrPRAdmin(ImportExportModelAdmin, admin.ModelAdmin):
 
     list_display = [id, 'fecha_y_hora_de_registro', 'origen', 'destino', 'estado' , 'obtener_remito'] #
     search_fields = [id, 'origen', 'destino', 'estado']
+
+
+# distribucion de productos ------
+class MovimientosDistribucionResource(resources.ModelResource):
+    class Meta:
+        model = Distribucion
+
+
+class MovimientosDistribucionProductoResource(resources.ModelResource):
+    class Meta:
+        model = DistribucionProducto
+
+
+class LineaDeDistribucionProductoResource(resources.ModelResource):
+    class Meta:
+        model = LineaDistribucionProducto
+
+
+class LineaDeDistribucionProductoInLine(admin.TabularInline):
+    class Meta:
+        model = LineaDistribucionProducto
+
+    model = LineaDistribucionProducto
+    # fields = ['id', 'producto', 'porcentaje']
+    list_display = ['id', 'pc', 'porcentaje']
+
+
+class EditLinkToInlineObject(object):
+    # clase para obtener link de edicion a menu admin inline
+    def edit_link(self, instance):
+        url = reverse('admin:%s_%s_change' % (
+            instance._meta.app_label, instance._meta.model_name), args=[instance.pk])
+        if instance.pk:
+            return mark_safe(u'<a href="{u}">Editar</a>'.format(u=url))
+        else:
+            return ''
+
+
+class DistribucionProductoInLine(EditLinkToInlineObject, admin.TabularInline):
+    # estas son las lineas de cada distribucion a pc
+    class Meta:
+        model = DistribucionProducto
+    model = DistribucionProducto
+    fields = ['id', 'edit_link', 'producto', 'total_asignado']
+    readonly_fields = ['edit_link', 'total_asignado']
+
+
+class DistribucionProductoAdmin(admin.ModelAdmin):
+    # estas son las distribuciones, debe haber solo una por cada ingreso
+    class Meta:
+        model = DistribucionProducto
+    inlines = [LineaDeDistribucionProductoInLine]
+    resource_class = MovimientosDistribucionProductoResource
+    fields = ['producto', 'distribucion', 'total_asignado']
+    list_display = ['id', 'producto']
+    search_fields = ['id', 'producto']
+    readonly_fields = ['total_asignado']
+
+    # con esta funcion oculto el acceso a via menu pero permito que se modifique directamente
+    # def get_model_perms(self, request):
+    #   return {}
+
+    def response_post_save_change(self, request, obj):
+        #el objeto que llega es la linea del producto que acabo de guardar
+        acumulador = 0
+        for pc in LineaDistribucionProducto.objects.filter(distribucion_id=obj.id):
+            acumulador += pc.porcentaje
+        #if acumulador <= 100: esta verificacion creo q iria en el formset_save. PREGUNTAR
+        obj.total_asignado = acumulador
+        obj.save()
+        id_distribucion = Distribucion.objects.get(id=obj.distribucion_id).id
+        return redirect(
+            "/Movimientos/distribucion/%s/change/" % (id_distribucion))  # Preguntar si esto esta bien o es una mala practica
+        # arreglar para q si se elimina tambien devuelva al menu distribucion o que no muestre el boton eliminar a la
+        # derecha debajo de los guardar
+
+
+class DistribucionAdmin(admin.ModelAdmin):
+    class Meta:
+        model = Distribucion
+
+    inlines = [DistribucionProductoInLine]
+    resource_class = MovimientosDistribucionResource
+    list_display = ['id', 'ingreso']
+    search_fields = ['id', 'ingreso']
+    actions = [make_carga_productos_automatica]
+
+
+admin.site.register(Distribucion, DistribucionAdmin)
+admin.site.register(DistribucionProducto, DistribucionProductoAdmin)
 
 admin.site.register(IngresosAPuntosDeRecepcion, IngPRAdmin)
 admin.site.register(EgresosPuntoDeRecepcion, EgrPRAdmin)

--- a/Logistica_dj/Logistica/Movimientos/models.py
+++ b/Logistica_dj/Logistica/Movimientos/models.py
@@ -81,3 +81,38 @@ class LineaDeEgr(models.Model):
 
     def __str__(self):
         return "EG-PR #{}".format(str(id(self)))
+
+
+# Cambios para distribucion
+class Distribucion(models.Model):
+    class Meta:
+        verbose_name = "Distribucion"
+        verbose_name_plural = "Distribuciones"
+    ingreso = models.ForeignKey(IngresosAPuntosDeRecepcion, on_delete=models.CASCADE, verbose_name="Ingreso")
+
+    def __str__(self):
+        return "DISTRIBUCION #{}".format(str(self.id))
+
+
+class DistribucionProducto(models.Model):
+    class Meta:
+        verbose_name = "Distribucion Producto"
+        verbose_name_plural = "Distribuciones Productos"
+    producto = models.ForeignKey(Producto, on_delete=models.CASCADE, verbose_name="Producto")
+    distribucion = models.ForeignKey(Distribucion, on_delete=models.CASCADE, verbose_name="Distribucion")
+    total_asignado = models.FloatField(default=0)
+
+    def __str__(self):
+        return "D-Prod #{}".format(str(self.id))
+
+
+class LineaDistribucionProducto(models.Model):
+    class Meta:
+        verbose_name = "Linea de Distribucion de Producto"
+        verbose_name_plural = "Lineas de Distribucion de Productos"
+    distribucion = models.ForeignKey(DistribucionProducto, on_delete=models.CASCADE)
+    pc = models.ForeignKey(PuntoDeConsumo, on_delete=models.CASCADE, verbose_name="Punto de Consumo")
+    porcentaje = models.FloatField(default=0) #deberia ser solo positivo
+
+    def __str__(self):
+        return "LD-Prod #{}".format(str(self.id))


### PR DESCRIPTION
Se puede crear una distribucion y asociarla a un ingreso. Desde el menu de distribucion hay una opcion para cargar los productos a partir del ingreso asociado. Luego por cada producto se puede editar y asignarle el porcentaje correspondiente a los diferentes pc. 
Se pueden generar los egresos automaticamente una vez creada la distribucion para el ingreso, debe cambiarse el estado del ingreso a validado para poder hacerlo.
Comente las lineas de stock en Logistica/urls.py porque me daba error.
Falta agregar la funcion para que el receptor de un egreso pueda ser un pr.